### PR TITLE
Use a standard python lib to get the filename extension.

### DIFF
--- a/WikiParser.py
+++ b/WikiParser.py
@@ -52,18 +52,16 @@ class WikiParser(object):
         if outputLanguage == inputLanguage:
             raise ValueError("Error: Input Language (" + inputLanguage + ") same as output Language (" + outputLanguage + ")")
 
-        self.mOutputFilename = ""
+        # Extract the raw input filename and its extension.
+        rawInputFilename, inputFilenameExtension = os.path.splitext(inputFilename)
 
-        if (len(inputFilename.split('.')) == 2):
-            # File has an extension
-            self.mOutputFilename = inputFilename.split('.')[0] + '-' + outputLanguage + '.' + inputFilename.split('.')[1]
-        else:
-            self.mOutputFilename = inputFilename + '-' + outputLanguage
+        # Construct the output filename.
+        self.mOutputFilename = rawInputFilename + '-' + outputLanguage + inputFilenameExtension
 
         # Keep track of the input filename.
         self.mInputFilename = inputFilename
 
-        # Main data structure is a list of objects
+        # Main data structure is a list of objects.
         self.mMedia = []
 
         # Get a file handle to the input mediawiki file.


### PR DESCRIPTION
Previously we were looking for a '.' in the file name which is okay when using an absolute path. However when we have relative paths such as ../export/desktop/Firefox.txt then we need to be able to extract the filename and its extension.