### PR TITLE
Enhancement to extract the Google project ID from the credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.json
 *.pyc
 settings

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This script uses Google Cloud Translate API to translate mediwiki markup files.
 
 ```
 $ pip install --upgrade google-cloud-translate
+$ pip install configparser
 ```
 
 ### Google Cloud Translate set-up
@@ -15,11 +16,11 @@ $ pip install --upgrade google-cloud-translate
 - Create a project
 - Enable Translation API
 - Create a service account with Translate permissions
-- Download the private key as credentials.json in this same folder
+- Download the private key as ``credentials.json`` in this same folder
 
 ### Settings
 
-Rename ``settings_example`` into ``settings`` and change your project_id.
+Rename ``settings_example`` into ``settings``.
 
 ## Usage
 

--- a/WikiParser.py
+++ b/WikiParser.py
@@ -14,19 +14,48 @@ from google.cloud import translate_v3beta1 as translate
 # So we can generate some random number ranges.
 import random
 
+# Parsing of JSON file(s).
+import json
+
+# Setup environment using project settings.
 import configparser
 
-parser = configparser.ConfigParser()
-parser.read('settings')
+# Name of the project settings file.
+SETTINGS_FILENAME = 'settings'
+# Settings sub-section within the settings file.
+SETTINGS_SECTION = 'settings'
 
-section = parser['settings']
+# Local parser to process the project settings.
+parser = configparser.ConfigParser()
+dataset = parser.read(SETTINGS_FILENAME)
+
+# Verify that the user has set up their settings environment.
+if len(dataset) != 1:
+    errMsg = "Error: Missing settings file (" + SETTINGS_FILENAME
+    errMsg += ") copy settings_example to " + SETTINGS_FILENAME
+    raise ValueError(errMsg)
+
+section = parser[SETTINGS_SECTION]
 
 os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = section['GOOGLE_APPLICATION_CREDENTIALS']
 DEFAULT_INPUT_LANGUAGE = section['DEFAULT_INPUT_LANGUAGE']
 DEFAULT_OUTPUT_LANGUAGE = section['DEFAULT_OUTPUT_LANGUAGE']
-project_id = section['project_id']
 location = section['location']
 
+# Verify that the credentials file exists.
+if not os.path.exists(section['GOOGLE_APPLICATION_CREDENTIALS']):
+    errMsg = "Error: Missing input settings Google App Credentials file ("
+    errMsg += section['GOOGLE_APPLICATION_CREDENTIALS'] + ")"
+    raise ValueError(errMsg)
+
+# Get the Google Cloud Project ID from the private key credentials file.
+with open(section['GOOGLE_APPLICATION_CREDENTIALS'], 'r') as googleCredentialsFile:
+
+    # Parse the credential's JSON file into dictionary.
+    googleCredentialsJson = json.load(googleCredentialsFile)
+
+# Google Application Project ID.
+project_id = googleCredentialsJson['project_id']
 
 class WikiParser(object):
 

--- a/settings_example
+++ b/settings_example
@@ -1,6 +1,5 @@
 [settings]
 GOOGLE_APPLICATION_CREDENTIALS = ./credentials.json
-project_id = my-project-456882
 location = global
 DEFAULT_INPUT_LANGUAGE = en
 DEFAULT_OUTPUT_LANGUAGE = es


### PR DESCRIPTION
Instead of specifying the Google Project ID within the settings file we can now extract this info from the credentials.json.

This way the project id is only specified in one place, which is inside of the credentials file.

Updated the associated documentation in the README.md and the example_settings file to reflect the changes in the setup.