### PR TITLE
Update testcases as we previously had two failing tests for http.

### DIFF
--- a/test_wikiparser.py
+++ b/test_wikiparser.py
@@ -462,6 +462,7 @@ class TestWikiParser(unittest.TestCase):
                      "lineNumber": 99,
                      "sequenceLine": "",
                      "sequences": [],
+                     "usedSequenceNumbers": [],
                      "emptyLine": False}
 
         # Build the Device Under Test.
@@ -486,6 +487,7 @@ class TestWikiParser(unittest.TestCase):
                      "lineNumber": 99,
                      "sequenceLine": "",
                      "sequences": [],
+                     "usedSequenceNumbers": [],
                      "emptyLine": False}
 
         # Build the Device Under Test.


### PR DESCRIPTION
Tests are now passing there was a missing field in the test-cases.

Let me know once you have the additional http example input, and then I can add an extra test case to this existing issue #7 so that can get that into the regression test suite under this existing ticket.

