### PR TITLE
Issue/7/extra spaces added to normal urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,23 @@ Rename ``settings_example`` into ``settings``.
 
 Usage examples:
 
-You don't need to specify a language we can just default to Spanish
-``$ ./mediawiki.py --input orig_input.txt``
+You don't need to specify a language we can just default to Spanish.
+```
+$ ./mediawiki.py --input orig_input.txt
+```
 
-Specify a specific single language
+Specify a specific single language.
 ```
 $ ./mediawiki.py --input orig_input.txt --lang es
 $ ./mediawiki.py --input orig_input.txt --lang ru
 ```
 
-Specify multiple languages for a single file
+Specify multiple languages for a single file.
 ```
 $ ./mediawiki.py --input orig_input.txt --lang 'es,ru'
 ```
 
-Or you can specify a weird language and the error message shall tell you what are supported
+Or you can specify a weird language and the error message shall tell you what are supported.
 ```
 $ ./mediawiki.py --input orig_input.txt --lang unknown
 ```
@@ -57,7 +59,7 @@ For multiple files in a single directory and we want to generate multiple output
 $ ./mediawiki.py --indir myinputdirectory/ --lang 'ru,es'
 ```
 
-If you want to send the translated files to a different directory you can specify an outdir
+If you want to send the translated files to a different directory you can specify an outdir (note that you don't need the slash on the end of the directory names).
 ```
 $ ./mediawiki.py --indir myinputdirectory/ --lang 'ru,es' --outdir myoutputdirectory/
 ```
@@ -96,18 +98,18 @@ orig_input.txt -> script -> orgi_output.txt
 1. Create and write to output file.
 
 #### Error conditions
-- Cannot find input file
-- Empty input file
-- Format of input file not valid according to mediawiki
-- Unable to send requests to Cloud Translation
-- Unable to create output file
+- Cannot find input file.
+- Empty input file.
+- Format of input file not valid according to mediawiki.
+- Unable to send requests to Cloud Translation.
+- Unable to create output file.
 
 #### Data structure(s)
 
 ##### List of objects
 - Object - for each line in the input file.
   - Original Line - Original line of text from the input file, in English, say.
-  - Translated Line - The final translated line of text into the requested output language
+  - Translated Line - The final translated line of text into the requested output language.
   - Line number - Line number of the input file.
   - Sequence Line - After special sequences of interest within the original line have been replaced with a special squences so that we don't want to translate these.
   - Sequences - List of the unique sequences in the current line, we may or may not want to translate individually.
@@ -123,22 +125,24 @@ orig_input.txt -> script -> orgi_output.txt
 
 #### Control Flow
 1. Start with the parsing of the input arguments to verify them.
-1. Parse over the input file
-1. Look at one line at a time
+1. Parse over the input file.
+1. Look at one line at a time.
 1. Look for specific patterns of interest in the input file and if they are special then remove them from the line and replace them with a unique tag.
-1. Then send the remaining line to Google Cloud Translate API
-1. Each of the special unique tags replace them with the original content
-1. OR some of the special unique tags we need to still translate them but just a bit of their content
-1. write the line to the output file
+1. Then send the remaining line to Google Cloud Translate API.
+1. Each of the special unique tags replace them with the original content.
+1. OR some of the special unique tags we need to still translate them but just a bit of their content.
+1. write the line to the output file.
 
 #### Data Flow
 - Need to add more details here.
 
 ### Test-cases
 
-Run the local script called runTest.sh
+Run the local script called runTest.sh.
 
-``$ ./runTests.sh``
+```
+$ ./runTests.sh
+```
 
 This local script uses the package pytest in order to run a suite of unit tests.
 
@@ -146,11 +150,15 @@ This local script uses the package pytest in order to run a suite of unit tests.
 
 Or to run the test suite in verbose mode, for a suite of tests, you can say,
 
-``$ pytest -v test_wikiparser.py``
+```
+$ pytest -v test_wikiparser.py
+```
 
 ### Run a single test-case
 
 Or to run just a single testcase called test_filepath_directive, from the test suite TestWikiParser, in verbose mode, you can say,
 
-``$ pytest -v test_wikiparser.py::TestWikiParser::test_filepath_directive``
+```
+$ pytest -v test_wikiparser.py::TestWikiParser::test_filepath_directive
+```
 

--- a/WikiParser.py
+++ b/WikiParser.py
@@ -280,7 +280,7 @@ class WikiParser(object):
                                          "translate": False},
                                         {"pattern":"\[\[Video\:[\w\s\:\/\.\_]+\]\]",
                                          "translate": False},
-                                        {"pattern":"\[\[([\s\w\-\_\#\,\"]+)\|[\w\s]+\]\]",
+                                        {"pattern":"\[\[([\s\w\-\_\#\,\"\?]+)\|[\w\s\,\"]+\]\]",
                                          "translate": False},
                                         {"pattern":"\[\[T\:[\w\s\-\|\=\_]+\]\]",
                                          "translate": False},
@@ -312,6 +312,8 @@ class WikiParser(object):
                                          "translate": False},
                                         {"pattern":"(\"[\s\w\-\_\#\,\.\?\:\>\<\/]+\")",
                                          "translate": True},
+                                        {"pattern":"(\'\'http[\s\w\-\_\#\,\.\?\:\>\<\/]+\'\')",
+                                         "translate": False},
                                     ]
 
         # Patterns we want to replace with a special unique tag then we can put it back after

--- a/mediawiki.py
+++ b/mediawiki.py
@@ -171,7 +171,7 @@ def main():
                 mediawikiParser.readProcessTranslateWrite()
 
     # DEBUG: Report the data structure of special sequences.
-    # mediawikiParser.printWikiParser()
+    mediawikiParser.printWikiParser()
 
     # End of main.
     return

--- a/mediawiki.py
+++ b/mediawiki.py
@@ -171,7 +171,7 @@ def main():
                 mediawikiParser.readProcessTranslateWrite()
 
     # DEBUG: Report the data structure of special sequences.
-    mediawikiParser.printWikiParser()
+    # mediawikiParser.printWikiParser()
 
     # End of main.
     return

--- a/test_wikiparser.py
+++ b/test_wikiparser.py
@@ -15,6 +15,15 @@ class TestWikiParser(unittest.TestCase):
     # Create the Device Under Test (DUT).
     #
     def setup_method(self, method):
+
+        # Set-up the line that you would like to test.
+        self.inputLine = {"originalLine": "",
+                          "translatedLine": "",
+                          "lineNumber": 99,
+                          "sequenceLine": "",
+                          "sequences": [],
+                          "usedSequenceNumbers": [],
+                          "emptyLine": False}
         pass
 
     #
@@ -56,21 +65,16 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
-        inputLine = {"originalLine": "{for not fx67}",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        # Modify test input line.
+        self.inputLine["originalLine"] = "{for not fx67}"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -81,21 +85,16 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
-        inputLine = {"originalLine": "#[[Template:openextensions]]",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        # Modify test input line.
+        self.inputLine["originalLine"] = "#[[Template:openextensions]]"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -106,21 +105,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\#\*[\s\w]+\."
 
-        inputLine = {"originalLine": "#*This will open a panel where you can manage extension settings.",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "#*This will open a panel where you can manage extension settings."
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -131,21 +124,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "[\s\w]+\,[\s\w]+\.[\s\w]+\d+\-\d+\s*\,[\s\w]+"
 
-        inputLine = {"originalLine": "Underneath the description of the extension, you will see extension settings. Next to ''Run in Private Windows'', select",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "Underneath the description of the extension, you will see extension settings. Next to ''Run in Private Windows'', select"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -156,21 +143,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
-        inputLine = {"originalLine": "__TOC__",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "__TOC__"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -181,21 +162,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "[\s\w]+\{\s*\d+\-\d+\s*\}[\s\w]+\."
 
-        inputLine = {"originalLine": "to add a check mark and then click on the {button Okay, Got It} bar.",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "to add a check mark and then click on the {button Okay, Got It} bar."
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -206,21 +181,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
-        inputLine = {"originalLine": "=Extensions in private windows=",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "=Extensions in private windows="
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -231,21 +200,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
-        inputLine = {"originalLine": "{/for}",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "{/for}"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -256,21 +219,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
-        inputLine = {"originalLine": "{note}",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "{note}"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -281,21 +238,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
-        inputLine = {"originalLine": "{/note}",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "{/note}"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -306,21 +257,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
-        inputLine = {"originalLine": "'''Note:'''",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "'''Note:'''"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -331,21 +276,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\[\[\s+\d+\-\d+\s+\|Firefox\s+version\]\]"
 
-        inputLine = {"originalLine": "[[Find what version of Firefox you are using|Firefox version]]",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "[[Find what version of Firefox you are using|Firefox version]]"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -356,21 +295,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
-        inputLine = {"originalLine": ";[[Image:Fx67ExtensionInstall-AllowPrivate]]",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = ";[[Image:Fx67ExtensionInstall-AllowPrivate]]"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -382,21 +315,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "Mozilla\'s\s*CA\s*Certificate\s*Program\s*publishes\s*a\s*list\s*of\s*\d+\-\d+\s*which\s*contains\s*details\s*that\s*might\s*be\s*useful\s*to\s*the\s*website\s*owners\."
 
-        inputLine = {"originalLine": "Mozilla's CA Certificate Program publishes a list of [https://wiki.mozilla.org/CA/Upcoming_Distrust_Actions upcoming policy actions affecting certificate authorities] which contains details that might be useful to the website owners.",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "Mozilla's CA Certificate Program publishes a list of [https://wiki.mozilla.org/CA/Upcoming_Distrust_Actions upcoming policy actions affecting certificate authorities] which contains details that might be useful to the website owners."
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -407,21 +334,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\#\s*Press\s*\d+\-\d+\s*\d+\-\d+\s*\+\s*\d+\-\d+\s*\d+\-\d+\s*\."
 
-        inputLine = {"originalLine": "# Press {for mac}{key command}+{/for}{key Delete}.",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "# Press {for mac}{key command}+{/for}{key Delete}."
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -432,21 +353,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\#\s*Press\s*\d+\-\d+\s*\d+\-\d+\s*\+\s*\d+\-\d+\s*\."
 
-        inputLine = {"originalLine": "# Press {for mac}{filepath mypath}+{/for}.",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "# Press {for mac}{filepath mypath}+{/for}."
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -457,21 +372,15 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\s*\d+\-\d+[\s\w]+\,[\s\w]+https\:\/\/support\.mozilla\.org\/en\-US\/kb\/get\-started\-firefox\-overview\-main\-features\/discuss\/7308\s*\d+\-\d+\s*"
 
-        inputLine = {"originalLine": "<!-- The next two surveys are ONLY for the US, see https://support.mozilla.org/en-US/kb/get-started-firefox-overview-main-features/discuss/7308-->",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "<!-- The next two surveys are ONLY for the US, see https://support.mozilla.org/en-US/kb/get-started-firefox-overview-main-features/discuss/7308-->"
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
@@ -482,22 +391,52 @@ class TestWikiParser(unittest.TestCase):
         expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "[\s\w]+\d+\-\d+[\s\w]+\."
 
-        inputLine = {"originalLine": "to your [https://getpocket.com/ Pocket] list so you can read them whenever and wherever you want.",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        self.inputLine["originalLine"] = "to your [https://getpocket.com/ Pocket] list so you can read them whenever and wherever you want."
 
         # Build the Device Under Test.
         self.dut = WikiParser.WikiParser(expectedFilename)
 
-        self.dut.processMediaWikiLine(inputLine)
+        self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
-        currentMatch = re.findall(currentPattern, inputLine["sequenceLine"])
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
 
         assert len(currentMatch) == 1
 
+    def test_http_inside_curved_backets_with_double_quotes(self):
 
+        # Expected outputs.
+        expectedRawFilename = "orig_input"
+        expectedFilename = expectedRawFilename + ".txt"
+        expectedSequence = "\(\s*\d+\-\d+[\s\w]+\[\[\s*\d+\-\d+\s*\|\s*\d+\-\d+[\s\w]+\,[\s\w]+\]\]\.\)"
+
+        self.inputLine["originalLine"] = "('''Tip:''' A secure connection will have [[How do I tell if my connection to a website is secure?#w_green-padlock|\"HTTPS\" in the address bar, along with a green lock icon]].)"
+
+        # Build the Device Under Test.
+        self.dut = WikiParser.WikiParser(expectedFilename)
+
+        self.dut.processMediaWikiLine(self.inputLine)
+
+        currentPattern = re.compile(expectedSequence, re.IGNORECASE)
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
+
+        assert len(currentMatch) == 1
+
+    def test_http_inside_double_of_single_quotes(self):
+
+        # Expected outputs.
+        expectedRawFilename = "orig_input"
+        expectedFilename = expectedRawFilename + ".txt"
+        expectedSequence = "[\s\w]+\,[\s\w]+\d+\-\d+[\s\w]+\."
+
+        self.inputLine["originalLine"] = "If a login page for your favorite site is insecure, you can try and see if a secure version of the page exists by typing ''https://'' before the URL in the address bar."
+
+        # Build the Device Under Test.
+        self.dut = WikiParser.WikiParser(expectedFilename)
+
+        self.dut.processMediaWikiLine(self.inputLine)
+
+        currentPattern = re.compile(expectedSequence, re.IGNORECASE)
+        currentMatch = re.findall(currentPattern, self.inputLine["sequenceLine"])
+
+        assert len(currentMatch) == 1


### PR DESCRIPTION
Added a couple or more tests to deal with the more complex http links that can occur with the input file.

Also cleaned up a bit of the documentation so it looks nicer to read, formatting.

The test-cases are now easier to write because we have a test input object that is created initially in the pytest setup_method() then we can just change the bits we need for that specific test-case. So the tests are now easier to read and create.