### PR TITLE
Can now specify command line parameters in any order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ $ pip install configparser
 
 ### Google Cloud Translate set-up
 [Set-up Google Cloud translate](https://cloud.google.com/translate/docs/quickstart-v3)
-- Create a project
-- Enable Translation API
-- Create a service account with Translate permissions
-- Download the private key as ``credentials.json`` in this same folder
+- Create a project.
+- Enable Translation API.
+- Create a service account with Translate permissions.
+- Download the Google Cloud private key as ``credentials.json``, say, in this same folder.
 
 ### Settings
 
@@ -33,7 +33,7 @@ Rename ``settings_example`` into ``settings``.
 
 Usage examples:
 
-You don't need to specify a language we can just default to Spanish.
+You don't need to specify a language we can just default to the language that is specified in your settings file.
 ```
 $ ./mediawiki.py --input orig_input.txt
 ```
@@ -61,10 +61,16 @@ $ ./mediawiki.py --indir myinputdirectory/ --lang 'ru,es'
 
 If you want to send the translated files to a different directory you can specify an outdir (note that you don't need the slash on the end of the directory names).
 ```
-$ ./mediawiki.py --indir myinputdirectory/ --lang 'ru,es' --outdir myoutputdirectory/
+$ ./mediawiki.py --indir my-input-directory/ --lang 'ru,es' --outdir my-output-directory/
 ```
 
 Note that if the output directory does not already exist, then it is created.
+
+If you want to have your settings file named something other than the default value of ``settings`` then you can provide this.
+```
+$ ./mediawiki.py --indir my-input-directory/ --lang 'ru,es' --outdir my-output-directory/ --settings custom-settings-filename.txt
+```
+
 
 ## Other notes
 
@@ -73,11 +79,12 @@ Translate an input mediawiki file of Spanish and generate an output mediawiki fi
 orig_input.txt -> script -> orgi_output.txt
 
 ### Inputs
-- input file
-- Language of output file (default: Spanish)
+- Input input-filename - Input mediawiki file.
+- Language of output file (default language is specified in ``settings`` file)
 - Language of output files can be a list of languages eg 'ru,es' would be for Russian and Spanish.
-- input directory - so need to get a list of all files in that directory and then parse each one of them.
-- output directory - place the translated files into the output directory.
+- Input directory - so need to get a list of all files in that directory and then parse each one of them.
+- Output directory - place all the translated files into the output directory.
+- Input settings file - provides custom default languages and location of Google App API credentials JSON file.
 
 ### Outputs
 - output file with the name of the file "myfile-es.txt' if the input is "myfile.txt", for a target language of es.

--- a/WikiParser.py
+++ b/WikiParser.py
@@ -14,55 +14,12 @@ from google.cloud import translate_v3beta1 as translate
 # So we can generate some random number ranges.
 import random
 
-# Parsing of JSON file(s).
-import json
-
-# Setup environment using project settings.
-import configparser
-
-# Name of the project settings file.
-SETTINGS_FILENAME = 'settings'
-# Settings sub-section within the settings file.
-SETTINGS_SECTION = 'settings'
-
-# Local parser to process the project settings.
-parser = configparser.ConfigParser()
-dataset = parser.read(SETTINGS_FILENAME)
-
-# Verify that the user has set up their settings environment.
-if len(dataset) != 1:
-    errMsg = "Error: Missing settings file (" + SETTINGS_FILENAME
-    errMsg += ") copy settings_example to " + SETTINGS_FILENAME
-    raise ValueError(errMsg)
-
-section = parser[SETTINGS_SECTION]
-
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = section['GOOGLE_APPLICATION_CREDENTIALS']
-DEFAULT_INPUT_LANGUAGE = section['DEFAULT_INPUT_LANGUAGE']
-DEFAULT_OUTPUT_LANGUAGE = section['DEFAULT_OUTPUT_LANGUAGE']
-location = section['location']
-
-# Verify that the credentials file exists.
-if not os.path.exists(section['GOOGLE_APPLICATION_CREDENTIALS']):
-    errMsg = "Error: Missing input settings Google App Credentials file ("
-    errMsg += section['GOOGLE_APPLICATION_CREDENTIALS'] + ")"
-    raise ValueError(errMsg)
-
-# Get the Google Cloud Project ID from the private key credentials file.
-with open(section['GOOGLE_APPLICATION_CREDENTIALS'], 'r') as googleCredentialsFile:
-
-    # Parse the credential's JSON file into dictionary.
-    googleCredentialsJson = json.load(googleCredentialsFile)
-
-# Google Application Project ID.
-project_id = googleCredentialsJson['project_id']
 
 class WikiParser(object):
 
     # Constructor.
     # Default Language is used if nothing specified.
-    def __init__(self, inputFilename, outputLanguage=DEFAULT_OUTPUT_LANGUAGE,
-                 inputLanguage=DEFAULT_INPUT_LANGUAGE, outputDirname=None):
+    def __init__(self, inputFilename, outputLanguage, inputLanguage, location, projectId, outputDirname=None):
 
         # Check the input arguments.
         if not inputFilename:
@@ -122,7 +79,7 @@ class WikiParser(object):
 
         # Instantiates a translation client.
         self.mTranslateClient = translate.TranslationServiceClient()
-        self.mParent = self.mTranslateClient.location_path(project_id, location)
+        self.mParent = self.mTranslateClient.location_path(projectId, location)
 
 
     #

--- a/WikiSettings.py
+++ b/WikiSettings.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+
+# Setup environment using project settings.
+import configparser
+
+# Parsing of JSON file(s).
+import json
+
+# Access operating system libraries to check if file or directory exist.
+import os
+
+# Custom common data.
+import WikiData
+
+#
+# Set up the environment for Media Wiki by extracting information from the settings file.
+#
+def extractSettings(settingsFilename='settings'):
+
+    # Settings sub-section within the settings file.
+    SETTINGS_SECTION = 'settings'
+    SETTINGS_GOOGLE_APPLICATION_CREDENTIALS = 'GOOGLE_APPLICATION_CREDENTIALS'
+    SETTINGS_LOCATION = 'location'
+    SETTINGS_DEFAULT_INPUT_LANGUAGE = 'DEFAULT_INPUT_LANGUAGE'
+    SETTINGS_DEFAULT_OUTPUT_LANGUAGE = 'DEFAULT_OUTPUT_LANGUAGE'
+    SETTINGS_EXPECTED = [SETTINGS_GOOGLE_APPLICATION_CREDENTIALS,
+                         SETTINGS_LOCATION,
+                         SETTINGS_DEFAULT_INPUT_LANGUAGE,
+                         SETTINGS_DEFAULT_OUTPUT_LANGUAGE]
+
+    # Local parser to process the project settings.
+    parser = configparser.ConfigParser()
+
+    if not os.path.exists(settingsFilename):
+        raise ValueError("Error: Settings file (" + settingsFilename + ") does not exist.")
+
+    if not os.path.isfile(settingsFilename):
+        raise ValueError("Error: Settings file (" + settingsFilename + ") is not a file.")
+
+    if os.path.getsize(settingsFilename) <= 0:
+        raise ValueError("Error: Settings file (" + settingsFilename + ") is empty.")
+
+    # Read and parese the input settings file.
+    dataset = parser.read(settingsFilename)
+
+    # Get the part of the settings file that is under the settings section.
+    if SETTINGS_SECTION in parser.keys():
+        section = parser[SETTINGS_SECTION]
+    else:
+        errStr = "Error: Missing [" + SETTINGS_SECTION + "]"
+        errStr += " section from settings file (" + settingsFilename + ")"
+        raise ValueError(errStr)
+
+    # Verify the settings we expect to see in the input settings file.
+    for expectedSetting in SETTINGS_EXPECTED:
+        if section.get(expectedSetting, None) is None:
+            errStr = "Error: Setting (" + expectedSetting
+            errStr += ") missing from settings file (" + settingsFilename + ")\n"
+            raise ValueError(errStr)
+
+    # Set up the Google API Application credentials
+    os.environ[SETTINGS_GOOGLE_APPLICATION_CREDENTIALS] = section.get(SETTINGS_GOOGLE_APPLICATION_CREDENTIALS, None)
+    inputLang = section.get(SETTINGS_DEFAULT_INPUT_LANGUAGE, None)
+    outputLang = section.get(SETTINGS_DEFAULT_OUTPUT_LANGUAGE, None)
+    location = section.get(SETTINGS_LOCATION, None)
+
+    # Verify that the credentials file exists.
+    if not os.path.exists(os.environ[SETTINGS_GOOGLE_APPLICATION_CREDENTIALS]):
+        errMsg = "Error: Missing input settings Google App credentials file ("
+        errMsg += os.environ[SETTINGS_GOOGLE_APPLICATION_CREDENTIALS] + ")"
+        raise ValueError(errMsg)
+
+    # Get the Google Cloud Project ID from the private key credentials file.
+    with open(os.environ[SETTINGS_GOOGLE_APPLICATION_CREDENTIALS], 'r') as googleCredentialsFile:
+
+        # Parse the credential's JSON file into dictionary.
+        googleCredentialsJson = json.load(googleCredentialsFile)
+
+    # Google Application Project ID.
+    projectId = googleCredentialsJson.get('project_id', None)
+
+    # Verify the expected settings are not empty.
+    if not location:
+        errStr = "Error: Setting (" +  SETTINGS_LOCATION
+        errStr += ") no value set from settings file (" + settingsFilename + ")\n"
+        raise ValueError(errStr)
+
+    if not projectId:
+        errStr = "Error: Project ID missing in credentials file ("
+        errStr += os.environ[SETTINGS_GOOGLE_APPLICATION_CREDENTIALS] + ")"
+        raise ValueError(errStr)
+
+    # Verify the default languages in the settings.
+    if not (inputLang in WikiData.SUPPORTED_LANGUAGES.keys()):
+        errStr = "Error: Setting (" +  SETTINGS_DEFAULT_INPUT_LANGUAGE
+        errStr += " = " + inputLang + ")"
+        errStr += " not supported from settings file (" + settingsFilename + ")\n"
+        errStr += "Supported are: " + str(supportedLanguagesString())
+        raise ValueError(errStr)
+
+    if not (outputLang in WikiData.SUPPORTED_LANGUAGES.keys()):
+        errStr = "Error: Setting (" +  SETTINGS_DEFAULT_OUTPUT_LANGUAGE
+        errStr += " = " + outputLang + ")"
+        errStr += " not supported from settings file (" + settingsFilename + ")\n"
+        errStr += "Supported are: " + str(supportedLanguagesString())
+        raise ValueError(errStr)
+
+    return inputLang, outputLang, location, projectId

--- a/test_wikiparser.py
+++ b/test_wikiparser.py
@@ -1,10 +1,22 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Test frame work.
 import pytest
 import unittest
-import WikiParser
+
+# Perform pattern matching through regular expressions.
 import re
+
+# Custom common data.
+import WikiData
+
+# Custom Mediawiki file package.
+import WikiParser
+
+# Custom settings.
+import WikiSettings
+
 
 #
 # Tests for the verification of parsing input files.
@@ -24,8 +36,20 @@ class TestWikiParser(unittest.TestCase):
                           "sequences": [],
                           "usedSequenceNumbers": [],
                           "emptyLine": False}
-        pass
 
+        # Deal with the settings file.
+        self.inputLangDefault, self.outputLangDefault, self.location, self.projectId = WikiSettings.extractSettings()
+
+        # Expected outputs.
+        self.expectedRawFilename = "orig_input"
+        self.expectedFilename = self.expectedRawFilename + ".txt"
+
+        # Build the Device Under Test.
+        self.dut = WikiParser.WikiParser(inputFilename = self.expectedFilename,
+                                         outputLanguage = self.outputLangDefault,
+                                         inputLanguage = self.inputLangDefault,
+                                         location = self.location,
+                                         projectId = self.projectId)
     #
     # Perform any necessary clean-up.
     #
@@ -37,40 +61,31 @@ class TestWikiParser(unittest.TestCase):
     ##############
 
     def test_invalid_inputfile_none(self):
-        self.assertRaises(ValueError, WikiParser.WikiParser, None)
+        self.assertRaises(ValueError, WikiParser.WikiParser, None, self.outputLangDefault, self.inputLangDefault,
+                          self.location, self.projectId)
 
     def test_invalid_inputfile_empty(self):
-        self.assertRaises(ValueError, WikiParser.WikiParser, "")
+        self.assertRaises(ValueError, WikiParser.WikiParser, "", self.outputLangDefault, self.inputLangDefault,
+                          self.location, self.projectId)
 
     def test_invalid_inputfile_emptyfile(self):
-        self.assertRaises(ValueError, WikiParser.WikiParser, "empty_input.txt")
+        self.assertRaises(ValueError, WikiParser.WikiParser, "empty_input.txt", self.outputLangDefault,
+                          self.inputLangDefault, self.location, self.projectId)
 
     def test_valid_inputfile_txt(self):
-
-        # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
-
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
-        assert self.dut.mInputFilename == expectedFilename
+        assert self.dut.mInputFilename == self.expectedFilename
 
     ##### Now lets test the parsing of some simple lines ###
 
     def test_template_for_not_fx67(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
         # Modify test input line.
         self.inputLine["originalLine"] = "{for not fx67}"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -81,16 +96,12 @@ class TestWikiParser(unittest.TestCase):
     def test_template_open_extensions(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
         # Modify test input line.
         self.inputLine["originalLine"] = "#[[Template:openextensions]]"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -101,15 +112,11 @@ class TestWikiParser(unittest.TestCase):
     def test_hash_star_string(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\#\*[\s\w]+\."
 
         self.inputLine["originalLine"] = "#*This will open a panel where you can manage extension settings."
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -120,15 +127,11 @@ class TestWikiParser(unittest.TestCase):
     def test_double_quotes(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "[\s\w]+\,[\s\w]+\.[\s\w]+\d+\-\d+\s*\,[\s\w]+"
 
         self.inputLine["originalLine"] = "Underneath the description of the extension, you will see extension settings. Next to ''Run in Private Windows'', select"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -139,15 +142,11 @@ class TestWikiParser(unittest.TestCase):
     def test_template_table_of_contents(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
         self.inputLine["originalLine"] = "__TOC__"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -158,15 +157,11 @@ class TestWikiParser(unittest.TestCase):
     def test_template_button(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "[\s\w]+\{\s*\d+\-\d+\s*\}[\s\w]+\."
 
         self.inputLine["originalLine"] = "to add a check mark and then click on the {button Okay, Got It} bar."
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -177,15 +172,11 @@ class TestWikiParser(unittest.TestCase):
     def test_equals_string_equals(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
         self.inputLine["originalLine"] = "=Extensions in private windows="
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -196,15 +187,11 @@ class TestWikiParser(unittest.TestCase):
     def test_template_slash_for(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
         self.inputLine["originalLine"] = "{/for}"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -215,15 +202,11 @@ class TestWikiParser(unittest.TestCase):
     def test_template_note(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
         self.inputLine["originalLine"] = "{note}"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -234,15 +217,11 @@ class TestWikiParser(unittest.TestCase):
     def test_template_slash_note(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
         self.inputLine["originalLine"] = "{/note}"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -253,15 +232,11 @@ class TestWikiParser(unittest.TestCase):
     def test_template_triple_quotes(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
         self.inputLine["originalLine"] = "'''Note:'''"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -272,15 +247,11 @@ class TestWikiParser(unittest.TestCase):
     def test_link_with_desription(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\[\[\s+\d+\-\d+\s+\|Firefox\s+version\]\]"
 
         self.inputLine["originalLine"] = "[[Find what version of Firefox you are using|Firefox version]]"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -291,15 +262,11 @@ class TestWikiParser(unittest.TestCase):
     def test_image_with_tag(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\d+\-\d+"
 
         self.inputLine["originalLine"] = ";[[Image:Fx67ExtensionInstall-AllowPrivate]]"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -311,15 +278,15 @@ class TestWikiParser(unittest.TestCase):
     def test_brackets_http(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
-        expectedSequence = "Mozilla\'s\s*CA\s*Certificate\s*Program\s*publishes\s*a\s*list\s*of\s*\d+\-\d+\s*which\s*contains\s*details\s*that\s*might\s*be\s*useful\s*to\s*the\s*website\s*owners\."
+        expectedSequence = "Mozilla\'s\s*CA\s*Certificate\s*Program\s*publishes\s*a\s*list\s*of\s*\d+\-\d+\s*"
+        expectedSequence += "which\s*contains\s*details\s*that\s*might\s*be\s*useful\s*to\s*the\s*website\s*owners\."
 
-        self.inputLine["originalLine"] = "Mozilla's CA Certificate Program publishes a list of [https://wiki.mozilla.org/CA/Upcoming_Distrust_Actions upcoming policy actions affecting certificate authorities] which contains details that might be useful to the website owners."
+        self.inputLine["originalLine"] = "Mozilla's CA Certificate Program publishes a list of "
+        self.inputLine["originalLine"] += "[https://wiki.mozilla.org/CA/Upcoming_Distrust_Actions upcoming policy "
+        self.inputLine["originalLine"] += "actions affecting certificate authorities] which contains details that "
+        self.inputLine["originalLine"] += "might be useful to the website owners."
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -330,15 +297,11 @@ class TestWikiParser(unittest.TestCase):
     def test_key_directive(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\#\s*Press\s*\d+\-\d+\s*\d+\-\d+\s*\+\s*\d+\-\d+\s*\d+\-\d+\s*\."
 
         self.inputLine["originalLine"] = "# Press {for mac}{key command}+{/for}{key Delete}."
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -349,15 +312,11 @@ class TestWikiParser(unittest.TestCase):
     def test_filepath_directive(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\#\s*Press\s*\d+\-\d+\s*\d+\-\d+\s*\+\s*\d+\-\d+\s*\."
 
         self.inputLine["originalLine"] = "# Press {for mac}{filepath mypath}+{/for}."
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -368,15 +327,11 @@ class TestWikiParser(unittest.TestCase):
     def test_http_inside_a_comment(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\s*\d+\-\d+[\s\w]+\,[\s\w]+https\:\/\/support\.mozilla\.org\/en\-US\/kb\/get\-started\-firefox\-overview\-main\-features\/discuss\/7308\s*\d+\-\d+\s*"
 
         self.inputLine["originalLine"] = "<!-- The next two surveys are ONLY for the US, see https://support.mozilla.org/en-US/kb/get-started-firefox-overview-main-features/discuss/7308-->"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -387,15 +342,11 @@ class TestWikiParser(unittest.TestCase):
     def test_http_inside_a_square_bracket(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "[\s\w]+\d+\-\d+[\s\w]+\."
 
         self.inputLine["originalLine"] = "to your [https://getpocket.com/ Pocket] list so you can read them whenever and wherever you want."
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -406,15 +357,11 @@ class TestWikiParser(unittest.TestCase):
     def test_http_inside_curved_backets_with_double_quotes(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "\(\s*\d+\-\d+[\s\w]+\[\[\s*\d+\-\d+\s*\|\s*\d+\-\d+[\s\w]+\,[\s\w]+\]\]\.\)"
 
         self.inputLine["originalLine"] = "('''Tip:''' A secure connection will have [[How do I tell if my connection to a website is secure?#w_green-padlock|\"HTTPS\" in the address bar, along with a green lock icon]].)"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)
@@ -425,15 +372,11 @@ class TestWikiParser(unittest.TestCase):
     def test_http_inside_double_of_single_quotes(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedSequence = "[\s\w]+\,[\s\w]+\d+\-\d+[\s\w]+\."
 
         self.inputLine["originalLine"] = "If a login page for your favorite site is insecure, you can try and see if a secure version of the page exists by typing ''https://'' before the URL in the address bar."
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
-
+        # Run the Device Under Test.
         self.dut.processMediaWikiLine(self.inputLine)
 
         currentPattern = re.compile(expectedSequence, re.IGNORECASE)

--- a/test_wikitranslation.py
+++ b/test_wikitranslation.py
@@ -1,10 +1,21 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Test frame work.
 import pytest
 import unittest
-import WikiParser
+
+# Perform pattern matching through regular expressions.
 import re
+
+# Custom common data.
+import WikiData
+
+# Custom Mediawiki file package.
+import WikiParser
+
+# Custom settings.
+import WikiSettings
 
 #
 # Tests for the Google translation of various text sequences.
@@ -15,7 +26,29 @@ class TestWikiTranslation(unittest.TestCase):
     # Create the Device Under Test (DUT).
     #
     def setup_method(self, method):
-        pass
+
+        # Set-up the line that you would like to test.
+        self.inputLine = {"originalLine": "",
+                          "translatedLine": "",
+                          "lineNumber": 99,
+                          "sequenceLine": "",
+                          "sequences": [],
+                          "usedSequenceNumbers": [],
+                          "emptyLine": False}
+
+        # Deal with the settings file.
+        self.inputLangDefault, self.outputLangDefault, self.location, self.projectId = WikiSettings.extractSettings()
+
+        # Expected outputs.
+        self.expectedRawFilename = "orig_input"
+        self.expectedFilename = self.expectedRawFilename + ".txt"
+
+        # Build the Device Under Test.
+        self.dut = WikiParser.WikiParser(inputFilename = self.expectedFilename,
+                                         outputLanguage = self.outputLangDefault,
+                                         inputLanguage = self.inputLangDefault,
+                                         location = self.location,
+                                         projectId = self.projectId)
 
     #
     # Perform any necessary clean-up.
@@ -26,50 +59,37 @@ class TestWikiTranslation(unittest.TestCase):
     ##############
     # Test-Cases #
     ##############
+
     ##### Now lets test the translation of some simple lines ###
 
     def test_translate_Firefox_version(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedTranslatedLine = "Version de firefox"
 
-        inputLine = {"originalLine": "Firefox version",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "Firefox version",
-                     "sequences": [],
-                     "usedSequenceNumbers": [],
-                     "emptyLine": False}
+        # Modify test input line.
+        self.inputLine["originalLine"] = "Firefox version"
+        self.inputLine["sequenceLine"] = "Firefox version"
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
+        # Run the Device Under Test.
+        self.dut.translateMediaWikiLine(self.inputLine)
 
-        self.dut.translateMediaWikiLine(inputLine)
-
-        assert expectedTranslatedLine.decode('utf8') == inputLine["translatedLine"]
+        assert expectedTranslatedLine.decode('utf8') == self.inputLine["translatedLine"]
 
     def test_translate_link_description(self):
 
         # Expected outputs.
-        expectedRawFilename = "orig_input"
-        expectedFilename = expectedRawFilename + ".txt"
         expectedTranslatedLine = "[[Find what version of Firefox you are using | Versión de Firefox]]"
 
-        inputLine = {"originalLine": "[[Find what version of Firefox you are using|Firefox version]]",
-                     "translatedLine": "",
-                     "lineNumber": 99,
-                     "sequenceLine": "[[ 123.456 |Firefox version]]",
-                     "sequences": [{"sequence": 123.456,
-                                    "original": "Find what version of Firefox you are using",
-                                    "translate": False}],
-                     "usedSequenceNumbers": [123.456],
-                     "emptyLine": False}
+        # Modify test input line.
+        self.inputLine["originalLine"] = "[[Find what version of Firefox you are using|Firefox version]]"
+        self.inputLine["sequenceLine"] = "[[ 123.456 |Firefox version]]"
+        self.inputLine["sequences"] = [{"sequence": 123.456,
+                                        "original": "Find what version of Firefox you are using",
+                                        "translate": False}]
+        self.inputLine["usedSequenceNumbers"] = [123.456]
 
-        # Build the Device Under Test.
-        self.dut = WikiParser.WikiParser(expectedFilename)
+        # Run the Device Under Test.
+        self.dut.translateMediaWikiLine(self.inputLine)
 
-        self.dut.translateMediaWikiLine(inputLine)
-
-        assert expectedTranslatedLine.decode('utf8') == inputLine["translatedLine"]
+        assert expectedTranslatedLine.decode('utf8') == self.inputLine["translatedLine"]


### PR DESCRIPTION
While I was making some changes for the command line parameters I have made some additional changes as a suggestion to this pull request.

- To parse the input settings file as its own python file,
- Updated the test-case suite to follow the DRY (Don't Repeat Yourself) principle,
- Allow the user to specify a settings file on the command line so there is an optional ``--settings`` switch
- Updated the README.md documentation to run in lock-step with the code implementation.

The regression suite is passing all 26 test-cases.